### PR TITLE
fix ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:18.04
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Из-за отсутствия конкретной версии базового образа начала подгружаться ubuntu 20, требующая выбрать регион для настройки времени. Данный фикс устраняет багу.

Если у гитхаба есть реджестри для образов (как у гитлаба), рекомендую все пакеты протегировать версяими по возможности и сделать текущий Dockerfile конфигом базового образа, а в проекте использовать уже базовый образ проекта (вместо базового образа Убунты).