### PR TITLE
add a workaround for racket installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM hexletbasics/base-image
 
-RUN add-apt-repository ppa:plt/racket
-RUN apt-get install -yqq racket
+RUN curl -o racket.sh \
+    https://mirror.racket-lang.org/installers/7.8/racket-7.8-x86_64-linux.sh && \
+    sh racket.sh --unix-style && \
+    rm racket.sh
 RUN raco pkg install \
     --scope installation --batch \
     --no-docs --no-cache --no-trash \


### PR DESCRIPTION
Добавил пока установку конкретной версии Racket из архива вместо PPA. А то автор линтера всё никак не сподобится обновить либу - у неё тесты падают на 7.9. И вообще ставить просто "последнюю версию" не стоит - сейчас у Racket меняют движок и новые релизы периодически что-то да ломают.