### PR TITLE
add test case

### DIFF
--- a/modules/40-lists/60-lists-and-recursion/test.rkt
+++ b/modules/40-lists/60-lists-and-recursion/test.rkt
@@ -9,5 +9,9 @@
   (check-equal? (skip 0 (list 1 2 3)) (list 1 2 3))
 
   (check-equal? (skip 1 (list 1 2 3)) (list 2 3))
+  
+  (check-equal? (skip 2 (list 1 2 3)) (list 3))
+  
+  (check-equal? (skip 3 (list 1 2 3)) (list))
 
   (check-equal? (skip 10 (list 1 2 3)) null))


### PR DESCRIPTION
сейчас тесты принимают такое решение:
```racket
(define (skip num l)
   (if (<= num 0)
     l
     (let ([len (length l)])
       (if (> num len) (list) 
         (let ([head (first l)]
               [tail (rest l)]) tail)))))
```
то есть при условии что число меньше длинны списка и больше нуля, достаточно вернуть хвост списка и система примет решение. добавил пару тест кейсов