### PR TITLE
Fix using “make-copy” instead of “string-copy” in strings/immutability

### DIFF
--- a/modules/50-strings/60-immutability/ru/README.md
+++ b/modules/50-strings/60-immutability/ru/README.md
@@ -39,7 +39,7 @@
 `string-set!` заменяет символ по указанному индексу на заданный:
 
 ```scheme
-(define s (make-copy "Cat")) ; изменяемая копия!
+(define s (string-copy "Cat")) ; изменяемая копия!
 (string-set! s 0 #\B)
 (string-set! s 1 #\o)
 (displayln s) ; => Bot


### PR DESCRIPTION
As I understand it, it’s just a typo.